### PR TITLE
fix Generate samples and frequency

### DIFF
--- a/src/main/java/com/github/psambit9791/jdsp/signal/Generate.java
+++ b/src/main/java/com/github/psambit9791/jdsp/signal/Generate.java
@@ -48,7 +48,7 @@ public class Generate {
      */
     public Generate(int start, int stop, int samplingFreq) {
         this.Fs = samplingFreq;
-        this.time = UtilMethods.linspace(start, stop, samplingFreq, true);
+        this.time = UtilMethods.linspace(start, stop, (stop-start)*samplingFreq, true);
     }
 
     /**


### PR DESCRIPTION
The Generate use linspace but give the argument samples the samplingFreq. The samples should be (stop-start)*samplingFreq instead.